### PR TITLE
fix: use ASDF_USER_SHIMS env var to get shims dir

### DIFF
--- a/lib/commands/command.bash
+++ b/lib/commands/command.bash
@@ -22,4 +22,4 @@ set \
   -o pipefail \
   -o errexit
 
-$ASDF_DIR/shims/syncher
+$ASDF_USER_SHIMS/syncher


### PR DESCRIPTION
`$ASDF_DIR` env var did not point to a dir that has the `shims` subdir on my machine.

The `$ASDF_USER_SHIMS` environment variable set by `$ASDF_DIR/asdf.sh` points to the shims directory directly.